### PR TITLE
fix: plugin icon will always be visible on startup

### DIFF
--- a/src/main/java/com/toofifty/goaltracker/GoalTrackerPlugin.java
+++ b/src/main/java/com/toofifty/goaltracker/GoalTrackerPlugin.java
@@ -41,6 +41,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.util.AsyncBufferedImage;
 
 @Slf4j
 @PluginDescriptor(name = "Goal Tracker", description = "Keep track of your goals and complete them automatically")
@@ -115,17 +116,18 @@ public class GoalTrackerPlugin extends Plugin
         itemCache.load();
         goalTrackerPanel.home();
 
-        final BufferedImage icon = itemManager.getImage(ItemID.TODO_LIST);
+        final AsyncBufferedImage icon = itemManager.getImage(ItemID.TODO_LIST);
 
-        uiNavigationButton = NavigationButton.builder()
-            .tooltip("Goal Tracker")
-            .icon(icon)
-            .priority(7)
-            .panel(goalTrackerPanel)
-            .build();
+        icon.onLoaded(() -> {
+            uiNavigationButton = NavigationButton.builder()
+                .tooltip("Goal Tracker")
+                .icon(icon)
+                .priority(7)
+                .panel(goalTrackerPanel)
+                .build();
 
-        clientToolbar.addNavigation(uiNavigationButton);
-
+            clientToolbar.addNavigation(uiNavigationButton);
+        });
     }
 
     @Override


### PR DESCRIPTION
### Description

Upon startup the item icon isn't available, as such we have to wait for it to be loaded before creating the `NavigationButton`

### Screenshots

#### Before

![image](https://github.com/Toofifty/rl-goal-tracker/assets/9692284/945e7b39-63e2-4aec-a2c2-4a40a17d2a57)

#### After

![image](https://github.com/Toofifty/rl-goal-tracker/assets/9692284/b0cb469d-0ae4-4909-809a-5c48d0ddba20)

relates to #8 