### PR TITLE
feat: allow tasks to be indented / unintended within the task list

### DIFF
--- a/src/main/java/com/toofifty/goaltracker/models/task/Task.java
+++ b/src/main/java/com/toofifty/goaltracker/models/task/Task.java
@@ -1,5 +1,6 @@
 package com.toofifty.goaltracker.models.task;
 
+import com.google.common.primitives.UnsignedInteger;
 import com.google.gson.annotations.SerializedName;
 import com.toofifty.goaltracker.models.enums.Status;
 import com.toofifty.goaltracker.models.enums.TaskType;
@@ -21,8 +22,32 @@ public abstract class Task
     @SerializedName("has_been_notified")
     private boolean notified = false;
 
+    @Builder.Default
+    @SerializedName("indent_level")
+    @Getter
+    private int indentLevel = 0;
+
+    transient final private int MAX_INDENT = 3;
+
     public boolean isDone() {
         return Status.COMPLETED.equals(this.status);
+    }
+
+
+    public void indent()
+    {
+        if (indentLevel < MAX_INDENT)
+        {
+            indentLevel += 1;
+        }
+    }
+
+    public void unindent()
+    {
+        if (indentLevel > 0)
+        {
+            indentLevel -= 1;
+        }
     }
 
     @Override

--- a/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
@@ -69,6 +69,18 @@ public class GoalPanel extends JPanel implements Refreshable
                 });
             }
 
+            taskPanel.onIndented(e -> {
+                task.indent();
+                this.taskUpdatedListener.accept(task);
+                plugin.getUiStatusManager().refresh(task);
+            });
+
+            taskPanel.onUnindented(e -> {
+                task.unindent();
+                this.taskUpdatedListener.accept(task);
+                plugin.getUiStatusManager().refresh(task);
+            });
+
             return taskPanel;
         });
         taskListPanel.setGap(0);

--- a/src/main/java/com/toofifty/goaltracker/ui/TaskItemContent.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/TaskItemContent.java
@@ -42,7 +42,10 @@ public class TaskItemContent extends JPanel implements Refreshable
     {
         titleLabel.setText(task.toString());
         titleLabel.setForeground(STATUS_TO_COLOR.get(task.getStatus()));
+
+        int indent = 16 * task.getIndentLevel();
         iconLabel.setIcon(iconService.get(task));
+        iconLabel.setBorder(new EmptyBorder(0, indent, 0, 0));
 
         revalidate();
     }

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
@@ -21,12 +21,17 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
     private final JMenuItem moveToTop = new JMenuItem("Move to top");
     private final JMenuItem moveToBottom = new JMenuItem("Move to bottom");
     private final JMenuItem removeTask = new JMenuItem("Remove");
+    private final JMenuItem indentTask = new JMenuItem("Indent");
+    private final JMenuItem unindentTask = new JMenuItem("Unindent");
     private final JPopupMenu popupMenu = new JPopupMenu();
 
     private final ReorderableList<T> list;
     private final T item;
+
     private Consumer<T> reorderedListener;
     private Consumer<T> removedListener;
+    private Consumer<T> indentedListener;
+    private Consumer<T> unindentedListener;
 
     public ListItemPanel(ReorderableList<T> list, T item)
     {
@@ -62,6 +67,16 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
             this.removedListener.accept(item);
         });
 
+
+
+        indentTask.addActionListener(e -> {
+            this.indentedListener.accept(item);
+        });
+
+        unindentTask.addActionListener(e -> {
+            this.unindentedListener.accept(item);
+        });
+
         popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 
         setComponentPopupMenu(popupMenu);
@@ -93,6 +108,14 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
         popupMenu.removeAll();
         if (!list.isFirst(item)) {
             popupMenu.add(moveUp);
+            if (this.indentedListener != null)
+            {
+                popupMenu.add(indentTask);
+            }
+            if (this.unindentedListener != null)
+            {
+                popupMenu.add(unindentTask);
+            }
         }
         if (!list.isLast(item)) {
             popupMenu.add(moveDown);
@@ -145,5 +168,14 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
 
     public void onReordered(Consumer<T> reorderListener) {
         this.reorderedListener = reorderListener;
+    }
+
+    public void onIndented(Consumer<T> indentedListener) {
+        this.indentedListener = indentedListener;
+    }
+
+    public void onUnindented(Consumer<T> unindentedListener) {
+        this.unindentedListener = unindentedListener;
+
     }
 }

--- a/src/test/java/com/toofifty/goaltracker/GoalSerializerTest.java
+++ b/src/test/java/com/toofifty/goaltracker/GoalSerializerTest.java
@@ -41,6 +41,7 @@ public class GoalSerializerTest {
         assertEquals(Status.COMPLETED, task.getStatus());
         assertTrue(task.isNotified());
         assertTrue(task.isDone());
+        assertEquals(0, task.getIndentLevel());
         assertEquals("Do all the things!", task.getDescription());
     }
 
@@ -57,12 +58,15 @@ public class GoalSerializerTest {
         assertEquals(5, goals.get(0).getTasks().size());
 
         assertEquals(ManualTask.class, goals.get(0).getTasks().get(0).getClass());
+        assertEquals(0, goals.get(0).getTasks().get(0).getIndentLevel());
         assertEquals(SkillLevelTask.class, goals.get(0).getTasks().get(1).getClass());
+        assertEquals(1, goals.get(0).getTasks().get(1).getIndentLevel());
 
         SkillLevelTask skillLevelTask = (SkillLevelTask) goals.get(0).getTasks().get(1);
 
         assertEquals(99, skillLevelTask.getLevel());
         assertEquals(Skill.ATTACK, skillLevelTask.getSkill());
+        assertEquals(1, skillLevelTask.getIndentLevel());
 
         assertEquals(SkillXpTask.class, goals.get(0).getTasks().get(2).getClass());
 
@@ -70,12 +74,14 @@ public class GoalSerializerTest {
 
         assertEquals(1234, skillXpTask.getXp());
         assertEquals(Skill.ATTACK, skillXpTask.getSkill());
+        assertEquals(2, skillXpTask.getIndentLevel());
 
         assertEquals(QuestTask.class, goals.get(0).getTasks().get(3).getClass());
 
         QuestTask questTask = (QuestTask) goals.get(0).getTasks().get(3);
 
         assertEquals(Quest.ANIMAL_MAGNETISM, questTask.getQuest());
+        assertEquals(1, questTask.getIndentLevel());
 
         assertEquals(ItemTask.class, goals.get(0).getTasks().get(4).getClass());
 
@@ -85,6 +91,7 @@ public class GoalSerializerTest {
         assertEquals(4, itemTask.getAcquired());
         assertEquals(10, itemTask.getQuantity());
         assertEquals("Feather", itemTask.getItemName());
+        assertEquals(0, itemTask.getIndentLevel());
     }
 
     @Test
@@ -100,11 +107,13 @@ public class GoalSerializerTest {
                         .description("Do all the things!")
                         .status(Status.COMPLETED)
                         .notified(true)
+                        .indentLevel(0)
                         .build())))
                 .build()
         );
 
         assertEquals(expectedJson, serializer.serialize(goals, true));
+        
     }
 
     @Test
@@ -120,27 +129,32 @@ public class GoalSerializerTest {
                                         .description("Do all the things!")
                                         .status(Status.COMPLETED)
                                         .notified(true)
+                                        .indentLevel(0)
                                         .build(),
                                 SkillLevelTask.builder()
                                         .status(Status.IN_PROGRESS)
                                         .notified(false)
+                                        .indentLevel(1)
                                         .level(99)
                                         .skill(Skill.ATTACK)
                                         .build(),
                                 SkillXpTask.builder()
                                         .status(Status.NOT_STARTED)
                                         .notified(false)
+                                        .indentLevel(2)
                                         .xp(1234)
                                         .skill(Skill.ATTACK)
                                         .build(),
                                 QuestTask.builder()
                                         .status(Status.NOT_STARTED)
                                         .notified(false)
+                                        .indentLevel(1)
                                         .quest(Quest.ANIMAL_MAGNETISM)
                                         .build(),
                                 ItemTask.builder()
                                         .status(Status.NOT_STARTED)
                                         .notified(false)
+                                        .indentLevel(0)
                                         .quantity(10)
                                         .acquired(4)
                                         .itemId(314)

--- a/src/test/resources/complex.json
+++ b/src/test/resources/complex.json
@@ -7,6 +7,7 @@
         "description": "Do all the things!",
         "previous_result": "completed",
         "has_been_notified": true,
+        "indent_level": 0,
         "type": "manual"
       },
       {
@@ -14,6 +15,7 @@
         "level": 99,
         "previous_result": "in_progress",
         "has_been_notified": false,
+        "indent_level": 1,
         "type": "skill_level"
       },
       {
@@ -21,12 +23,14 @@
         "xp": 1234,
         "previous_result": "not_started",
         "has_been_notified": false,
+        "indent_level": 2,
         "type": "skill_xp"
       },
       {
         "quest_id": 0,
         "previous_result": "not_started",
         "has_been_notified": false,
+        "indent_level": 1,
         "type": "quest"
       },
       {
@@ -36,6 +40,7 @@
         "item_name": "Feather",
         "previous_result": "not_started",
         "has_been_notified": false,
+        "indent_level": 0,
         "type": "item"
       }
     ]

--- a/src/test/resources/data.json
+++ b/src/test/resources/data.json
@@ -7,6 +7,7 @@
         "description": "Do all the things!",
         "previous_result": "completed",
         "has_been_notified": true,
+        "indent_level": 0,
         "type": "manual"
       }
     ]


### PR DESCRIPTION
Addressing feature request #6 by allowing tasks to be indented up to 3 times. User is also able to unindent them.