### PR TITLE
Implement support for moving tasks with Drag & Drop

### DIFF
--- a/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/GoalPanel.java
@@ -131,9 +131,9 @@ public final class GoalPanel extends JPanel implements Refreshable
             }
         });
 
-        taskListPanel = new ListPanel<>(goal.getTasks(), (task) -> {
+        taskListPanel = new ListPanel<>(goal.getTasks(), (parent, task) -> {
             try {
-                ListTaskPanel taskPanel = new ListTaskPanel(goal.getTasks(), task);
+                ListTaskPanel taskPanel = new ListTaskPanel(goal.getTasks(), task, parent);
                 taskPanel.setActionHistory(actionHistory);
                 TaskItemContent taskContent = new TaskItemContent(plugin, goal, task);
                 taskContent.setActionHistory(actionHistory);
@@ -169,7 +169,7 @@ public final class GoalPanel extends JPanel implements Refreshable
             } catch (Throwable t) {
                 t.printStackTrace();
                 // Render a minimal, visible error row instead of breaking the entire list
-                ListTaskPanel fallback = new ListTaskPanel(goal.getTasks(), task);
+                ListTaskPanel fallback = new ListTaskPanel(goal.getTasks(), task, parent);
                 JPanel error = new JPanel(new BorderLayout());
                 error.setOpaque(true);
                 error.setBackground(ColorScheme.DARK_GRAY_COLOR);

--- a/src/main/java/com/toofifty/goaltracker/ui/GoalTrackerPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/GoalTrackerPanel.java
@@ -121,8 +121,8 @@ public final class GoalTrackerPanel extends PluginPanel implements Refreshable
         headerContainer.add(titleWrapper, BorderLayout.NORTH);
         headerContainer.add(actionBar, BorderLayout.SOUTH);
 
-        goalListPanel = new ListPanel<>(goalManager.getGoals(), (goal) -> {
-            var panel = new ListItemPanel<>(goalManager.getGoals(), goal);
+        goalListPanel = new ListPanel<>(goalManager.getGoals(), (itemParent, goal) -> {
+            var panel = new ListItemPanel<>(goalManager.getGoals(), goal, itemParent);
             panel.onClick(e -> this.safeView(goal));
             panel.add(new GoalItemContent(plugin, goal));
             panel.onRemovedWithIndex(this::recordGoalRemoval);

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
@@ -53,8 +53,6 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
     {
         if (clickListenerAdapter == null) return;
         c.addMouseListener(clickListenerAdapter);
-        c.addMouseListener(mouseDragEventForwarder);
-        c.addMouseMotionListener(mouseDragEventForwarder);
         if (c instanceof java.awt.Container)
         {
             for (Component child : ((java.awt.Container) c).getComponents())
@@ -72,6 +70,20 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
             for (Component child : ((java.awt.Container) c).getComponents())
             {
                 addContextMenuListenerRecursive(child);
+            }
+        }
+    }
+
+    protected void addMouseDragEventForwarderRecursive(Component c)
+    {
+        if (mouseDragEventForwarder == null) return;
+        c.addMouseListener(mouseDragEventForwarder);
+        c.addMouseMotionListener(mouseDragEventForwarder);
+        if (c instanceof java.awt.Container)
+        {
+            for (Component child : ((java.awt.Container) c).getComponents())
+            {
+                addMouseDragEventForwarderRecursive(child);
             }
         }
     }
@@ -166,8 +178,7 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
             }
         });
 
-        addMouseListener(mouseDragEventForwarder);
-        addMouseMotionListener(mouseDragEventForwarder);
+        addMouseDragEventForwarderRecursive(this);
     }
 
     @Override

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListItemPanel.java
@@ -4,6 +4,7 @@ import com.toofifty.goaltracker.models.Goal;
 import com.toofifty.goaltracker.ui.Refreshable;
 import com.toofifty.goaltracker.utils.ReorderableList;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.components.MouseDragEventForwarder;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -43,6 +44,7 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
     protected BiConsumer<T, Integer> removedWithIndexListener;
 
     private MouseAdapter clickListenerAdapter;
+    MouseDragEventForwarder mouseDragEventForwarder;
 
     // Inner face of the goal card; only this area changes color on hover/press
     private JPanel cardBody;
@@ -51,6 +53,8 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
     {
         if (clickListenerAdapter == null) return;
         c.addMouseListener(clickListenerAdapter);
+        c.addMouseListener(mouseDragEventForwarder);
+        c.addMouseMotionListener(mouseDragEventForwarder);
         if (c instanceof java.awt.Container)
         {
             for (Component child : ((java.awt.Container) c).getComponents())
@@ -86,11 +90,12 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
         @Override public void mouseReleased(MouseEvent e) { maybeShow(e); }
     };
 
-    public ListItemPanel(ReorderableList<T> list, T item)
+    public ListItemPanel(ReorderableList<T> list, T item, JComponent parent)
     {
         super(new BorderLayout());
         this.list = list;
         this.item = item;
+        this.mouseDragEventForwarder = new MouseDragEventForwarder(parent);
 
         // Create inner card surface to isolate hover/press background changes
         cardBody = new JPanel(new BorderLayout());
@@ -160,6 +165,9 @@ public class ListItemPanel<T> extends JPanel implements Refreshable
                 }
             }
         });
+
+        addMouseListener(mouseDragEventForwarder);
+        addMouseMotionListener(mouseDragEventForwarder);
     }
 
     @Override

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
@@ -208,7 +208,6 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
 
             GridBagConstraints constraints = getConstraints();
             buildItemPanels().forEach(component -> {
-                listPanel.add(component);
                 listPanel.add(component, constraints);
                 constraints.gridy++;
             });

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
@@ -2,28 +2,30 @@ package com.toofifty.goaltracker.ui.components;
 
 import com.toofifty.goaltracker.ui.Refreshable;
 import com.toofifty.goaltracker.utils.ReorderableList;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.components.DragAndDropReorderPane;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
-import java.util.HashMap;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
  * Scrollable container that renders and manages a list of items with optional placeholder text.
  * Supports reordering, removal, and refresh of child panels.
  */
+@Slf4j
 public final class ListPanel<T> extends JScrollPane implements Refreshable
 {
-    private final JPanel listPanel = new JPanel(new GridBagLayout());
+    private final DragAndDropReorderPane listPanel = new DragAndDropReorderPane();
 
     private final ReorderableList<T> reorderableList;
-    private final Function<T, ListItemPanel<T>> renderItem;
+    private final BiFunction<JComponent, T, ListItemPanel<T>> renderItem;
 
     private final Map<T, ListItemPanel<T>> itemPanelMap = new HashMap<>();
 
@@ -36,16 +38,42 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
 
     public ListPanel(
         ReorderableList<T> reorderableList,
-        Function<T, ListItemPanel<T>> renderItem
+        BiFunction<JComponent, T, ListItemPanel<T>> renderItem
     ) {
         super();
         this.reorderableList = reorderableList;
         this.renderItem = renderItem;
 
-
         listPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
         // Add left/right padding so card content aligns with the header
         listPanel.setBorder(new EmptyBorder(0, 10, 0, 10));
+
+        listPanel.addDragListener(new DragAndDropReorderPane.DragListener() {
+            @Override
+            public void onDrag(Component component) {
+                T updatedItem = ((ListItemPanel<T>)component).item;
+                log.info("Dragged: " + updatedItem.toString());
+
+                reorderableList.sort(Comparator.comparing(item ->
+                {
+                    Component[] components = listPanel.getComponents();
+                    for (int idx = 0; idx < components.length; ++idx)
+                    {
+                        ListItemPanel<T> itemPanel = (ListItemPanel<T>) components[idx];
+                        if (itemPanel.item == item)
+                        {
+                            return idx;
+                        }
+                    }
+
+                    return -1;
+                }));
+
+                if (updatedListener != null) updatedListener.accept(updatedItem);
+
+                refresh();
+            }
+        });
 
         JPanel wrapperPanel = new JPanel(new BorderLayout());
         wrapperPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -116,7 +144,7 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
             return itemPanelMap.get(item);
         }
 
-        ListItemPanel<T> itemPanel = renderItem.apply(item);
+        ListItemPanel<T> itemPanel = renderItem.apply(listPanel, item);
 
         itemPanel.onReordered((updatedItem) -> {
             tryBuildList();
@@ -175,15 +203,18 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
             placeholderPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
             placeholderPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 0, 0));
             placeholderPanel.add(placeholder);
-            listPanel.add(placeholderPanel, getConstraints());
+//            listPanel.add(placeholderPanel, getConstraints());
+            listPanel.add(placeholderPanel);
         } else {
             listPanel.removeAll();
 
-            GridBagConstraints constraints = getConstraints();
-            buildItemPanels().forEach(component -> {
-                listPanel.add(component, constraints);
-                constraints.gridy++;
-            });
+            buildItemPanels().forEach(listPanel::add);
+//            GridBagConstraints constraints = getConstraints();
+//            buildItemPanels().forEach(component -> {
+//                listPanel.add(component);
+//                listPanel.add(component, constraints);
+//                constraints.gridy++;
+//            });
         }
 
         refreshChildMenus();

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListPanel.java
@@ -2,7 +2,6 @@ package com.toofifty.goaltracker.ui.components;
 
 import com.toofifty.goaltracker.ui.Refreshable;
 import com.toofifty.goaltracker.utils.ReorderableList;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.components.DragAndDropReorderPane;
 
@@ -19,7 +18,6 @@ import java.util.stream.Collectors;
  * Scrollable container that renders and manages a list of items with optional placeholder text.
  * Supports reordering, removal, and refresh of child panels.
  */
-@Slf4j
 public final class ListPanel<T> extends JScrollPane implements Refreshable
 {
     private final DragAndDropReorderPane listPanel = new DragAndDropReorderPane();
@@ -44,6 +42,7 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
         this.reorderableList = reorderableList;
         this.renderItem = renderItem;
 
+
         listPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
         // Add left/right padding so card content aligns with the header
         listPanel.setBorder(new EmptyBorder(0, 10, 0, 10));
@@ -52,8 +51,8 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
             @Override
             public void onDrag(Component component) {
                 T updatedItem = ((ListItemPanel<T>)component).item;
-                log.info("Dragged: " + updatedItem.toString());
 
+                // Sort the list based on the new order of the components in listPanel
                 reorderableList.sort(Comparator.comparing(item ->
                 {
                     Component[] components = listPanel.getComponents();
@@ -203,18 +202,16 @@ public final class ListPanel<T> extends JScrollPane implements Refreshable
             placeholderPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
             placeholderPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 0, 0));
             placeholderPanel.add(placeholder);
-//            listPanel.add(placeholderPanel, getConstraints());
-            listPanel.add(placeholderPanel);
+            listPanel.add(placeholderPanel, getConstraints());
         } else {
             listPanel.removeAll();
 
-            buildItemPanels().forEach(listPanel::add);
-//            GridBagConstraints constraints = getConstraints();
-//            buildItemPanels().forEach(component -> {
-//                listPanel.add(component);
-//                listPanel.add(component, constraints);
-//                constraints.gridy++;
-//            });
+            GridBagConstraints constraints = getConstraints();
+            buildItemPanels().forEach(component -> {
+                listPanel.add(component);
+                listPanel.add(component, constraints);
+                constraints.gridy++;
+            });
         }
 
         refreshChildMenus();

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListTaskPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListTaskPanel.java
@@ -43,8 +43,6 @@ public final class ListTaskPanel extends ListItemPanel<Task>
     private void addShiftRemoveListenerRecursive(Component c)
     {
         c.addMouseListener(shiftClickRemoveListener);
-        c.addMouseListener(this.mouseDragEventForwarder);
-        c.addMouseMotionListener(this.mouseDragEventForwarder);
         if (c instanceof Container)
         {
             for (Component child : ((Container) c).getComponents())
@@ -378,6 +376,7 @@ public final class ListTaskPanel extends ListItemPanel<Task>
         this.taskContent = taskContent;
         if (taskContent != null) {
             addShiftRemoveListenerRecursive(taskContent);
+            addMouseDragEventForwarderRecursive(taskContent);
         }
     }
 

--- a/src/main/java/com/toofifty/goaltracker/ui/components/ListTaskPanel.java
+++ b/src/main/java/com/toofifty/goaltracker/ui/components/ListTaskPanel.java
@@ -43,6 +43,8 @@ public final class ListTaskPanel extends ListItemPanel<Task>
     private void addShiftRemoveListenerRecursive(Component c)
     {
         c.addMouseListener(shiftClickRemoveListener);
+        c.addMouseListener(this.mouseDragEventForwarder);
+        c.addMouseMotionListener(this.mouseDragEventForwarder);
         if (c instanceof Container)
         {
             for (Component child : ((Container) c).getComponents())
@@ -52,9 +54,9 @@ public final class ListTaskPanel extends ListItemPanel<Task>
         }
     }
 
-    public ListTaskPanel(ReorderableList<Task> list, Task item)
+    public ListTaskPanel(ReorderableList<Task> list, Task item, JComponent parent)
     {
-        super(list, item);
+        super(list, item, parent);
 
         indentItem.addActionListener(e -> {
             int index = list.indexOf(item);


### PR DESCRIPTION
I'm a fan of this plugin, but I felt that the current approach of moving items around one spot at a time was pretty tedious, so I looked into how I could add support for using Drag & Drop to move tasks around.

I found that RuneLite has a `DragAndDropReorderPane` component that's already in use by a couple other plugins, and took a stab at integrating that into this plugin.

Before:

https://github.com/user-attachments/assets/0b407f8b-a5cc-41bb-9d47-2ffa11bf67b5

After:

https://github.com/user-attachments/assets/ee7373b0-d0c1-45f2-bb02-1b9dbd8090bc

Note: This does break some formatting applied by `GridBagConstraints`, since `DragAndDropReorderPane` has its own layout manager and cannot use the `GridBagLayout`