### PR TITLE
fix: remove quest enum refs not in RuneLite API (#60)

### DIFF
--- a/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
+++ b/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
@@ -1180,19 +1180,8 @@ public final class QuestRequirements
                 )
         );
 
-        REQUIREMENT_MAP.put(
-                Quest.AN_EXISTENTIAL_CRISIS,
-                Arrays.asList(
-                        QuestTask.builder().quest(Quest.THE_FINAL_DAWN).build()
-                )
-        );
-
-        REQUIREMENT_MAP.put(
-                Quest.IMPENDING_CHAOS,
-                Arrays.asList(
-                        QuestTask.builder().quest(Quest.THE_FINAL_DAWN).build()
-                )
-        );
+        // TODO: Add these quests when/if they're added to the game / re-added to the RuneLite Quest enum
+        // Quest.AN_EXISTENTIAL_CRISIS and Quest.IMPENDING_CHAOS
 
         REQUIREMENT_MAP.put(
                 Quest.VALE_TOTEMS,

--- a/src/test/java/com/toofifty/goaltracker/GoalSerializerTest.java
+++ b/src/test/java/com/toofifty/goaltracker/GoalSerializerTest.java
@@ -10,11 +10,14 @@ import com.toofifty.goaltracker.models.enums.Status;
 import com.toofifty.goaltracker.models.enums.TaskType;
 import com.toofifty.goaltracker.utils.ReorderableList;
 import com.google.common.io.Resources;
+import com.google.gson.Gson;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
@@ -25,7 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 //noinspection UnstableApiUsage
 @SuppressWarnings("null")
 public class GoalSerializerTest {
-    GoalSerializer serializer = new GoalSerializer();
+    GoalSerializer serializer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        serializer = new GoalSerializer();
+        Field gsonField = GoalSerializer.class.getDeclaredField("gson");
+        gsonField.setAccessible(true);
+        gsonField.set(serializer, new Gson());
+    }
 
     @Test
     public void deserialize_should_parse_successfully() throws IOException {

--- a/src/test/java/com/toofifty/goaltracker/services/TaskUpdateServiceTest.java
+++ b/src/test/java/com/toofifty/goaltracker/services/TaskUpdateServiceTest.java
@@ -62,6 +62,7 @@ class TaskUpdateServiceTest {
     @Test
     void update_skillLevelTask_shouldSupportLookingUpThePlayersLevel() {
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.isClientThread()).thenReturn(true);
         when(client.getRealSkillLevel(Skill.ATTACK)).thenReturn(99);
 
         SkillLevelTask task = SkillLevelTask.builder().skill(Skill.ATTACK).level(90).build();
@@ -118,6 +119,7 @@ class TaskUpdateServiceTest {
     @Test
     void update_skillXpTask_shouldSupportLookingUpThePlayersLevel() {
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.isClientThread()).thenReturn(true);
         when(client.getSkillExperience(Skill.ATTACK)).thenReturn(1234);
 
         SkillXpTask task = SkillXpTask.builder().skill(Skill.ATTACK).xp(1234).build();

--- a/src/test/java/com/toofifty/goaltracker/utils/QuestRequirementsTest.java
+++ b/src/test/java/com/toofifty/goaltracker/utils/QuestRequirementsTest.java
@@ -18,24 +18,29 @@ public class QuestRequirementsTest
     {
         List<Task> requirements = QuestRequirements.getRequirements(Quest.FAIRYTALE_I__GROWING_PAINS, 0);
         assertNotNull(requirements, "Requirements list should not be null");
-        assertEquals(3, requirements.size(), "Fairytale I should have 3 direct requirements");
+        // Recursive requirements: LOST_CITY + its 2 skills, NATURE_SPIRIT + its 3 reqs, Farming 18 = 8 total
+        assertEquals(8, requirements.size(), "Fairytale I should have 8 requirements (including recursive sub-quest requirements)");
 
-        // All items should be indented one level when called with indentLevel=0
-        requirements.forEach(t -> assertEquals(1, t.getIndentLevel(), "Each requirement should have indent 1"));
+        // Direct requirements at indent 1, sub-requirements at indent 2
+        long indent1Count = requirements.stream().filter(t -> t.getIndentLevel() == 1).count();
+        long indent2Count = requirements.stream().filter(t -> t.getIndentLevel() == 2).count();
+        assertEquals(3, indent1Count, "Should have 3 direct requirements at indent 1");
+        assertEquals(5, indent2Count, "Should have 5 sub-requirements at indent 2");
 
-        // Expect two quest tasks and one skill requirement
+        // With recursive requirements: 4 quests (LOST_CITY, NATURE_SPIRIT, PRIEST_IN_PERIL, THE_RESTLESS_GHOST)
+        // and 4 skills (Farming 18, Crafting 31, Woodcutting 36, Prayer 18)
         long questCount = requirements.stream().filter(t -> t instanceof QuestTask).count();
         long skillCount = requirements.stream().filter(t -> t instanceof SkillLevelTask).count();
-        assertEquals(2, questCount, "Should contain two QuestTask requirements");
-        assertEquals(1, skillCount, "Should contain one SkillLevelTask requirement");
+        assertEquals(4, questCount, "Should contain 4 QuestTask requirements (including sub-quest prereqs)");
+        assertEquals(4, skillCount, "Should contain 4 SkillLevelTask requirements (including sub-quest prereqs)");
 
-        // Verify specific quests are present
+        // Verify direct quest requirements are present
         boolean hasLostCity = requirements.stream().anyMatch(t -> t instanceof QuestTask && ((QuestTask) t).getQuest() == Quest.LOST_CITY);
         boolean hasNatureSpirit = requirements.stream().anyMatch(t -> t instanceof QuestTask && ((QuestTask) t).getQuest() == Quest.NATURE_SPIRIT);
         assertTrue(hasLostCity, "Lost City should be a requirement");
         assertTrue(hasNatureSpirit, "Nature Spirit should be a requirement");
 
-        // Verify specific skill requirement (Farming 18)
+        // Verify direct skill requirement (Farming 18)
         boolean hasFarming18 = requirements.stream().anyMatch(t -> t instanceof SkillLevelTask && ((SkillLevelTask) t).getSkill() == Skill.FARMING && ((SkillLevelTask) t).getLevel() == 18);
         assertTrue(hasFarming18, "Farming 18 should be a requirement");
     }

--- a/src/test/resources/complex.json
+++ b/src/test/resources/complex.json
@@ -2,10 +2,11 @@
   {
     "description": "My Goal",
     "display_order": -1,
+    "pinned": false,
     "items": [
       {
         "description": "Do all the things!",
-        "previous_result": "completed",
+        "status": "completed",
         "has_been_notified": true,
         "indent_level": 0,
         "type": "manual"
@@ -13,7 +14,7 @@
       {
         "skill": "Attack",
         "level": 99,
-        "previous_result": "in_progress",
+        "status": "in_progress",
         "has_been_notified": false,
         "indent_level": 1,
         "type": "skill_level"
@@ -21,14 +22,14 @@
       {
         "skill": "Attack",
         "xp": 1234,
-        "previous_result": "not_started",
+        "status": "not_started",
         "has_been_notified": false,
         "indent_level": 2,
         "type": "skill_xp"
       },
       {
         "quest_id": 0,
-        "previous_result": "not_started",
+        "status": "not_started",
         "has_been_notified": false,
         "indent_level": 1,
         "type": "quest"
@@ -38,7 +39,7 @@
         "acquired": 4,
         "item_id": 314,
         "item_name": "Feather",
-        "previous_result": "not_started",
+        "status": "not_started",
         "has_been_notified": false,
         "indent_level": 0,
         "type": "item"

--- a/src/test/resources/data.json
+++ b/src/test/resources/data.json
@@ -2,10 +2,11 @@
   {
     "description": "My Goal",
     "display_order": -1,
+    "pinned": false,
     "items": [
       {
         "description": "Do all the things!",
-        "previous_result": "completed",
+        "status": "completed",
         "has_been_notified": true,
         "indent_level": 0,
         "type": "manual"


### PR DESCRIPTION
Hey gang! Long-time user, first-time contributor :)
This should get the plugin back working in RuneLite.
Would love to help maintain and improve this project.

It's been a year or two since I touched Java, but I had a LOT of fun reading through the codebase / PR history before trying to resolve #60 

### Short Description
Fix plugin incompatibility error (#60) by removing Quest enum references not present in RuneLite API, and resolve 7 pre-existing test failures present since #42 was merged by the looks of it.

### What Has Changed

⚠️  **Commit 1: `fix: remove quest enum refs not in RuneLite API (#60)`**
- [x] Removed `Quest.AN_EXISTENTIAL_CRISIS` and `Quest.IMPENDING_CHAOS` from `QuestRequirements.java` (not in current RuneLite API)
> This is preventing usage from Plugin Hub currently

---

🧪  **Commit 2: `fix: resolve failing unit tests`**
- [x] `GoalSerializerTest.java` — Added `@BeforeEach` to inject Gson via reflection (fixes NPE)
- [x] `TaskUpdateServiceTest.java` — Added missing `client.isClientThread()` mock to 2 tests
- [x] `QuestRequirementsTest.java` — Updated assertions for recursive requirements (8 total, proper indent counts)
- [x] `data.json` / `complex.json` — `previous_result` → `status`, added `pinned: false`, normalized line endings

### Steps for Reviewing
1. Verify build passes: `./gradlew build`
2. Confirm all 91 tests pass: `./gradlew test`
3. Review `QuestRequirements.java` lines 1174–1185 for removed quest refs
4. Review test file changes for serialization/mock fixes

### Relevant tests
- `GoalSerializerTest.java`
- `TaskUpdateServiceTest.java`
- `QuestRequirementsTest.java`