### PR TITLE
removed unfinished quests from implementation making plugin compatible again

### DIFF
--- a/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
+++ b/src/main/java/com/toofifty/goaltracker/utils/QuestRequirements.java
@@ -1181,20 +1181,6 @@ public final class QuestRequirements
         );
 
         REQUIREMENT_MAP.put(
-                Quest.AN_EXISTENTIAL_CRISIS,
-                Arrays.asList(
-                        QuestTask.builder().quest(Quest.THE_FINAL_DAWN).build()
-                )
-        );
-
-        REQUIREMENT_MAP.put(
-                Quest.IMPENDING_CHAOS,
-                Arrays.asList(
-                        QuestTask.builder().quest(Quest.THE_FINAL_DAWN).build()
-                )
-        );
-
-        REQUIREMENT_MAP.put(
                 Quest.VALE_TOTEMS,
                 Arrays.asList(
                         QuestTask.builder().quest(Quest.THE_FINAL_DAWN).build()


### PR DESCRIPTION
These 2 quests have been removed from the runelite Quest class and caused the incompatible message. This PR fixes that by removing the unfinished quests in the implementation